### PR TITLE
fixing sha1sum for strap.sh

### DIFF
--- a/latex/blackarch-guide-en.tex
+++ b/latex/blackarch-guide-en.tex
@@ -175,7 +175,7 @@ Run \href{https://blackarch.org/strap.sh}{strap.sh} as root and follow the
 instructions. See the following example.
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # should match: 86eb4efb68918dbfdd1e22862a48fda20a8145ff
+   sha1sum strap.sh # should match: 6f152b79419491db92c1fdde3fad2d445f09aae3
    sudo ./strap.sh
 \end{lstlisting}
 

--- a/latex/blackarch-guide-pt-br.tex
+++ b/latex/blackarch-guide-pt-br.tex
@@ -168,7 +168,7 @@ O BlackArch é compatível como toda instalação do Arch.A instalação é feit
 Execute \href{https://blackarch.org/strap.sh}{strap.sh} como root e siga as instruções abaixo.
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # Deve ser igual a: 86eb4efb68918dbfdd1e22862a48fda20a8145ff
+   sha1sum strap.sh # Deve ser igual a: 6f152b79419491db92c1fdde3fad2d445f09aae3
    sudo ./strap.sh
 \end{lstlisting}
 Agora baixe uma copia atualizada da lista de pacotes e os sincronize.

--- a/latex/blackarch-guide-tr.tex
+++ b/latex/blackarch-guide-tr.tex
@@ -172,7 +172,7 @@ BlackArch normal bir Arch Linux kurulumu ile uyumludur. Resmi olmayan kullanÄ±cÄ
 
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # bu degere esit olmali: 86eb4efb68918dbfdd1e22862a48fda20a8145ff
+   sha1sum strap.sh # bu degere esit olmali: 6f152b79419491db92c1fdde3fad2d445f09aae3
    sudo ./strap.sh
 \end{lstlisting}
 


### PR DESCRIPTION
Fixing sha1sum, according to: https://github.com/BlackArch/blackarch/issues/1249

**Attention**, this pull should be accepted after https://github.com/BlackArch/blackarch-site/pull/72.