### PR TITLE
Add pdflatex to compile russian version

### DIFF
--- a/gen.sh
+++ b/gen.sh
@@ -31,7 +31,12 @@ make_final_html()
 
 if [ "${TARGET}" = "pdf" ]
 then
-    lualatex "${TEXFILE}"
+    if [[ "${TEXFILE}" =~ "ru" ]]
+    then
+        pdflatex "${TEXFILE}"
+    else
+        lualatex "${TEXFILE}"
+    fi
 elif [ "${TARGET}" = "html" ]
 then
     echo "not implemented"


### PR DESCRIPTION
Russian characters are not displayed in pdf when using lualatex.
I used pdflatex instead of lualatex.