### PR TITLE
Fixed translation error of Chinese

### DIFF
--- a/latex/blackarch-guide-zh.tex
+++ b/latex/blackarch-guide-zh.tex
@@ -130,7 +130,7 @@ BlackArch 是一个提供给渗透测试以及安全人员的完整的Linux发�
 
 工具集也被打包成 Arch Linux
 \href{https://wiki.archlinux.org/index.php/Unofficial\_User\_Repositories}
-{非官方用户仓库(AUR)}，所以你可以在一个已有的Arch Linux系统上安装。可以单独安装某个工具或按分类批量安装。
+{非官方用户仓库(Unofficial User Repositories)}，所以你可以在一个已有的Arch Linux系统上安装。可以单独安装某个工具或按分类批量安装。
 
 仓库目前包括超过 \href{https://www.blackarch.org/tools.html}{1300} 个工具，仍在不断扩充。
 为了保证仓库的质量，所有的工具在添加到代码库之前都经过测试。

--- a/latex/blackarch-guide-zh.tex
+++ b/latex/blackarch-guide-zh.tex
@@ -166,7 +166,7 @@ Github: \url{https://github.com/Blackarch/}
 接下来的几个小节会告诉你如何配置BlackArch仓库以及如何安装包。
 BlackArch支持用二进制安装包安装或是从代码安装。
 
-BlackArch 兼容 Arch Linux 常用的安装方式，比如说非官方用户仓库(AUR)。
+BlackArch 兼容 Arch Linux 常用的安装方式，比如说非官方用户仓库(Unofficial User Repositories)。
 如果你想使用ISO，参考
 \href{https://www.blackarch.org/downloads.html#iso}{Live ISO}。
 


### PR DESCRIPTION
Unofficial User Repositories， 非官方用户仓库 was abbreviated as AUR （Arch User Repositories ，Arch用户仓库），But the two are fundamentally different

Look Here：https://wiki.archlinux.org/index.php/Arch_User_Repository  and  https://wiki.archlinux.org/index.php/Unofficial_user_repositories


Unofficial User Repositories 非官方用户仓库被错误缩写为 AUR （Arch User Repositories ，Arch用户仓库），但这两者根本不同

参见：https://wiki.archlinux.org/index.php/Arch_User_Repository  与  https://wiki.archlinux.org/index.php/Unofficial_user_repositories