### PR TITLE
Update sha1sum of strap.sh

### DIFF
--- a/latex/blackarch-guide-de.tex
+++ b/latex/blackarch-guide-de.tex
@@ -183,7 +183,7 @@ Führe \href{https://blackarch.org/strap.sh}{strap.sh} als root aus und folge de
 Hier ein Beispiel.
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # should match: d062038042c5f141755ea39dbd615e6ff9e23121
+   sha1sum strap.sh # should match: 5ea40d49ecd14c2e024deecf90605426db97ea0c
    sudo chmod +x strap.sh
    sudo ./strap.sh
 \end{lstlisting}

--- a/latex/blackarch-guide-el.tex
+++ b/latex/blackarch-guide-el.tex
@@ -178,7 +178,7 @@ Discord: \url{https://discord.com/invite/xMHt8dW}
 οδηγίες. Δείτε το ακόλουθο παράδειγμα.
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # should match: d062038042c5f141755ea39dbd615e6ff9e23121
+   sha1sum strap.sh # should match: 5ea40d49ecd14c2e024deecf90605426db97ea0c
    sudo chmod +x strap.sh
    sudo ./strap.sh
 \end{lstlisting}

--- a/latex/blackarch-guide-en.tex
+++ b/latex/blackarch-guide-en.tex
@@ -177,7 +177,7 @@ Run \href{https://blackarch.org/strap.sh}{strap.sh} as root and follow the
 instructions. See the following example.
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # should match: d062038042c5f141755ea39dbd615e6ff9e23121
+   sha1sum strap.sh # should match: 5ea40d49ecd14c2e024deecf90605426db97ea0c
    sudo chmod +x strap.sh
    sudo ./strap.sh
 \end{lstlisting}

--- a/latex/blackarch-guide-es.tex
+++ b/latex/blackarch-guide-es.tex
@@ -192,7 +192,7 @@ Ejecute \href{https://blackarch.org/strap.sh}{strap.sh} como administrador y sig
 las instrucciones. Mire el ejemplo siguiente.
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # should match: d062038042c5f141755ea39dbd615e6ff9e23121
+   sha1sum strap.sh # should match: 5ea40d49ecd14c2e024deecf90605426db97ea0c
    sudo chmod +x strap.sh
    sudo ./strap.sh
 \end{lstlisting}

--- a/latex/blackarch-guide-fr.tex
+++ b/latex/blackarch-guide-fr.tex
@@ -166,7 +166,7 @@ Ex\'{e}cuter \href{https://blackarch.org/strap.sh}{strap.sh} en tant que root et
 
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # doit etre egal a d062038042c5f141755ea39dbd615e6ff9e23121
+   sha1sum strap.sh # doit etre egal a 5ea40d49ecd14c2e024deecf90605426db97ea0c
    sudo chmod +x strap.sh
    sudo ./strap.sh
 \end{lstlisting}

--- a/latex/blackarch-guide-id.tex
+++ b/latex/blackarch-guide-id.tex
@@ -177,7 +177,7 @@ Jalankan \href{https://blackarch.org/strap.sh}{strap.sh} sebagai root dan ikuti
 perintah-perintah. Lihat conth berikut.
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # should match: d062038042c5f141755ea39dbd615e6ff9e23121
+   sha1sum strap.sh # should match: 5ea40d49ecd14c2e024deecf90605426db97ea0c
    sudo chmod +x strap.sh
    sudo ./strap.sh
 \end{lstlisting}

--- a/latex/blackarch-guide-it.tex
+++ b/latex/blackarch-guide-it.tex
@@ -171,7 +171,7 @@ BlackArch è compatibile con le normali installazioni Arch. Si comporta come un 
 Esegui \href{https://blackarch.org/strap.sh}{strap.sh} come root e segui le istruzioni. Vedi l'esempio seguente.
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # should match: d062038042c5f141755ea39dbd615e6ff9e23121
+   sha1sum strap.sh # should match: 5ea40d49ecd14c2e024deecf90605426db97ea0c
    sudo chmod +x strap.sh
    sudo ./strap.sh
 \end{lstlisting}

--- a/latex/blackarch-guide-pt-br.tex
+++ b/latex/blackarch-guide-pt-br.tex
@@ -172,7 +172,7 @@ O BlackArch é compatível como toda instalação do Arch. A instalação é fei
 Execute \href{https://blackarch.org/strap.sh}{strap.sh} como root e siga as instruções abaixo.
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # Deve ser igual a: d062038042c5f141755ea39dbd615e6ff9e23121
+   sha1sum strap.sh # Deve ser igual a: 5ea40d49ecd14c2e024deecf90605426db97ea0c
    sudo chmod +x strap.sh
    sudo ./strap.sh
 \end{lstlisting}

--- a/latex/blackarch-guide-ro.tex
+++ b/latex/blackarch-guide-ro.tex
@@ -174,7 +174,7 @@ BlackArch este compatibil cu normala instalare Arch.Este exact ca un neoficial '
 Ruleaza \href{https://blackarch.org/strap.sh}{strap.sh} ca root urmand urmatoarele instructiuni. Urmatorul exemplu
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # should match: d062038042c5f141755ea39dbd615e6ff9e23121
+   sha1sum strap.sh # should match: 5ea40d49ecd14c2e024deecf90605426db97ea0c
    sudo chmod +x strap.sh
    sudo ./strap.sh
 \end{lstlisting}

--- a/latex/blackarch-guide-ru.tex
+++ b/latex/blackarch-guide-ru.tex
@@ -185,7 +185,7 @@ BlackArch совместим с обычной установкой Arch. Он �
 и следуйте инструкциям. Смотрите следующий пример.
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # should match: d062038042c5f141755ea39dbd615e6ff9e23121
+   sha1sum strap.sh # should match: 5ea40d49ecd14c2e024deecf90605426db97ea0c
    sudo chmod +x strap.sh
    sudo ./strap.sh
 \end{lstlisting}

--- a/latex/blackarch-guide-tr.tex
+++ b/latex/blackarch-guide-tr.tex
@@ -174,7 +174,7 @@ BlackArch normal bir Arch Linux kurulumu ile uyumludur. Resmi olmayan kullanÄ±cÄ
 
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # bu degere esit olmali: d062038042c5f141755ea39dbd615e6ff9e23121
+   sha1sum strap.sh # bu degere esit olmali: 5ea40d49ecd14c2e024deecf90605426db97ea0c
    sudo chmod +x strap.sh
    sudo ./strap.sh
 \end{lstlisting}

--- a/latex/blackarch-guide-zh.tex
+++ b/latex/blackarch-guide-zh.tex
@@ -176,7 +176,7 @@ BlackArch 兼容 Arch Linux 常用的安装方式，比如说非官方用户仓�
 用root权限运行脚本 \href{https://blackarch.org/strap.sh}{strap.sh}，并跟随提示，看下面的例子：
 \begin{lstlisting}
    curl -O https://blackarch.org/strap.sh
-   sha1sum strap.sh # should match: d062038042c5f141755ea39dbd615e6ff9e23121
+   sha1sum strap.sh # should match: 5ea40d49ecd14c2e024deecf90605426db97ea0c
    sudo chmod +x strap.sh
    sudo ./strap.sh
 \end{lstlisting}


### PR DESCRIPTION
The new value is taken from https://blackarch.org/downloads.html, and can also be verified manually from https://github.com/BlackArch/blackarch-site/blob/master/strap.sh