### PR TITLE
removed Discord link, added Matrix link

### DIFF
--- a/latex/blackarch-guide-de.tex
+++ b/latex/blackarch-guide-de.tex
@@ -31,7 +31,8 @@
 \widowpenalty10000
 \displaywidowpenalty=10000
 \usepackage{ltablex}
-\keepXColumns
+
+\keepXColumns
 
 %%% LAYOUT %%%
 \setlength{\parindent}{0em}
@@ -160,8 +161,6 @@ IRC: \url{irc://irc.freenode.net/blackarch}
 Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
-
-Discord: \url{https://discord.com/invite/xMHt8dW}
 
 %------------------%
 %  Kapitel 2       %

--- a/latex/blackarch-guide-de.tex
+++ b/latex/blackarch-guide-de.tex
@@ -162,6 +162,8 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
+Matrix: \url{https://matrix.to/#/#BlackArch:matrix.org}
+
 %------------------%
 %  Kapitel 2       %
 %------------------%

--- a/latex/blackarch-guide-el.tex
+++ b/latex/blackarch-guide-el.tex
@@ -154,8 +154,6 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
-Discord: \url{https://discord.com/invite/xMHt8dW}
-
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-el.tex
+++ b/latex/blackarch-guide-el.tex
@@ -154,6 +154,8 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
+Matrix: \url{https://matrix.to/#/#BlackArch:matrix.org}
+
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-en.tex
+++ b/latex/blackarch-guide-en.tex
@@ -154,8 +154,6 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
-Discord: \url{https://discord.com/invite/xMHt8dW}
-
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-en.tex
+++ b/latex/blackarch-guide-en.tex
@@ -154,6 +154,8 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
+Matrix: \url{https://matrix.to/#/#BlackArch:matrix.org}
+
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-es.tex
+++ b/latex/blackarch-guide-es.tex
@@ -169,6 +169,8 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
+Matrix: \url{https://matrix.to/#/#BlackArch:matrix.org}
+
 %------------------%
 %  Capitulo 2      %
 %------------------%

--- a/latex/blackarch-guide-es.tex
+++ b/latex/blackarch-guide-es.tex
@@ -169,8 +169,6 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
-Discord: \url{https://discord.com/invite/xMHt8dW}
-
 %------------------%
 %  Capitulo 2      %
 %------------------%

--- a/latex/blackarch-guide-fr.tex
+++ b/latex/blackarch-guide-fr.tex
@@ -150,8 +150,6 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
-Discord: \url{https://discord.com/invite/xMHt8dW}
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \chapter{Guide d'utilisation}

--- a/latex/blackarch-guide-fr.tex
+++ b/latex/blackarch-guide-fr.tex
@@ -150,6 +150,8 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
+Matrix: \url{https://matrix.to/#/#BlackArch:matrix.org}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \chapter{Guide d'utilisation}

--- a/latex/blackarch-guide-id.tex
+++ b/latex/blackarch-guide-id.tex
@@ -154,8 +154,6 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
-Discord: \url{https://discord.com/invite/xMHt8dW}
-
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-id.tex
+++ b/latex/blackarch-guide-id.tex
@@ -154,6 +154,8 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
+Matrix: \url{https://matrix.to/#/#BlackArch:matrix.org}
+
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-it.tex
+++ b/latex/blackarch-guide-it.tex
@@ -152,6 +152,8 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
+Matrix: \url{https://matrix.to/#/#BlackArch:matrix.org}
+
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-it.tex
+++ b/latex/blackarch-guide-it.tex
@@ -152,8 +152,6 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
-Discord: \url{https://discord.com/invite/xMHt8dW}
-
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-pt-br.tex
+++ b/latex/blackarch-guide-pt-br.tex
@@ -154,8 +154,6 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
-Discord: \url{https://discord.com/invite/xMHt8dW}
-
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-pt-br.tex
+++ b/latex/blackarch-guide-pt-br.tex
@@ -154,6 +154,8 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
+Matrix: \url{https://matrix.to/#/#BlackArch:matrix.org}
+
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-ro.tex
+++ b/latex/blackarch-guide-ro.tex
@@ -153,6 +153,8 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
+Matrix: \url{https://matrix.to/#/#BlackArch:matrix.org}
+
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-ro.tex
+++ b/latex/blackarch-guide-ro.tex
@@ -153,8 +153,6 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
-Discord: \url{https://discord.com/invite/xMHt8dW}
-
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-ru.tex
+++ b/latex/blackarch-guide-ru.tex
@@ -163,6 +163,8 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
+Matrix: \url{https://matrix.to/#/#BlackArch:matrix.org}
+
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-ru.tex
+++ b/latex/blackarch-guide-ru.tex
@@ -163,8 +163,6 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
-Discord: \url{https://discord.com/invite/xMHt8dW}
-
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-tr.tex
+++ b/latex/blackarch-guide-tr.tex
@@ -154,8 +154,6 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
-Discord: \url{https://discord.com/invite/xMHt8dW}
-
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-tr.tex
+++ b/latex/blackarch-guide-tr.tex
@@ -154,6 +154,8 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
+Matrix: \url{https://matrix.to/#/#BlackArch:matrix.org}
+
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-zh.tex
+++ b/latex/blackarch-guide-zh.tex
@@ -155,8 +155,6 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
-Discord: \url{https://discord.com/invite/xMHt8dW}
-
 %------------------%
 %  Chapter 2       %
 %------------------%

--- a/latex/blackarch-guide-zh.tex
+++ b/latex/blackarch-guide-zh.tex
@@ -155,6 +155,8 @@ Twitter: \url{https://twitter.com/blackarchlinux}
 
 Github: \url{https://github.com/Blackarch/}
 
+Matrix: \url{https://matrix.to/#/#BlackArch:matrix.org}
+
 %------------------%
 %  Chapter 2       %
 %------------------%


### PR DESCRIPTION
removed invite link to BlackArch Discord server as the server is dead and invite link no longer valid.
Replaced with link to Matrix room that's currently used instead.